### PR TITLE
Read local modules in both formats

### DIFF
--- a/lib/puppetfile_editor/module.rb
+++ b/lib/puppetfile_editor/module.rb
@@ -14,7 +14,7 @@ module PuppetfileEditor
       @params  = nil
       @message = nil
       @status  = nil
-      if args == { local: true } || args == :local
+      if [{ local: true }, :local].include? args
         @type = :local
       elsif args.nil? || args.is_a?(String) || args.is_a?(Symbol)
         @type   = :forge

--- a/lib/puppetfile_editor/module.rb
+++ b/lib/puppetfile_editor/module.rb
@@ -14,7 +14,7 @@ module PuppetfileEditor
       @params  = nil
       @message = nil
       @status  = nil
-      if args == :local
+      if args == { local: true } || args == :local
         @type = :local
       elsif args.nil? || args.is_a?(String) || args.is_a?(Symbol)
         @type   = :forge


### PR DESCRIPTION
This is the first part of #3.
Likely to be the last `0.x` release, this is able to read local modules in both legacy and new format.
Still outputs legacy format only.