### PR TITLE
Write local modules in non-legacy format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- [GH-3](https://github.com/pegasd/puppetfile_editor/issues/3): Write local modules in non-legacy format: `, local: true`.
 
 ## [0.10.0] - 2019-08-10
 ### Added
-- Able to understand local modules in various formats. Both `, :local` and `, local: true` work.
+- [GH-3](https://github.com/pegasd/puppetfile_editor/issues/3): Able to understand local modules in various formats. Both `, :local` and
+  `, local: true` work.
 
 ## [0.9.0] - 2019-08-06
 ### Changed
@@ -16,7 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.8.0] - 2018-07-12
 ### Changed
-- [#1](https://github.com/pegasd/puppetfile_editor/issues/1): Do not downgrade modules while merging, whenever possible (see issue for more details).
+- [GH-1](https://github.com/pegasd/puppetfile_editor/issues/1): Do not downgrade modules while merging, whenever possible (see issue for
+  more details).
 - Changed status message and color for modules not found in original Puppetfile (old one generated too much noise).
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.10.0] - 2019-08-10
+### Added
+- Able to understand local modules in various formats. Both `, :local` and `, local: true` work.
+
 ## [0.9.0] - 2019-08-06
 ### Changed
 - Add ability to compare Puppetfiles ignoring module types (`git` vs `hg`).

--- a/lib/puppetfile_editor/module.rb
+++ b/lib/puppetfile_editor/module.rb
@@ -117,7 +117,7 @@ module PuppetfileEditor
       end
     end
 
-    def dump
+    def dump(legacy_local = false)
       output = []
       case @type
       when :hg, :git
@@ -132,7 +132,11 @@ module PuppetfileEditor
           output.push "    #{param} #{value}"
         end
       when :local
-        output.push("mod '#{full_title}', :local")
+        if legacy_local
+          output.push("mod '#{full_title}', :local")
+        else
+          output.push("mod '#{full_title}', local: true")
+        end
       else
         if @params.nil?
           output.push("mod '#{full_title}'")

--- a/lib/puppetfile_editor/module.rb
+++ b/lib/puppetfile_editor/module.rb
@@ -14,7 +14,7 @@ module PuppetfileEditor
       @params  = nil
       @message = nil
       @status  = nil
-      if args == { local: true } || args == :local
+      if [{ local: true }, :local].include? args
         @type = :local
       elsif args.nil? || args.is_a?(String) || args.is_a?(Symbol)
         @type   = :forge

--- a/lib/puppetfile_editor/version.rb
+++ b/lib/puppetfile_editor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PuppetfileEditor
-  VERSION = '0.9.0'
+  VERSION = '0.10.0'
 end

--- a/spec/fixtures/unformatted/Puppetfile
+++ b/spec/fixtures/unformatted/Puppetfile
@@ -20,4 +20,4 @@ mod 'lsyncd',	 :local
 mod 'kibastic',     :local
 mod 'mongo',	 :local
 mod 's3cmd',	 :local
-mod 'vcsrepo',   :local
+mod 'vcsrepo',   local: true

--- a/spec/puppetfile_spec.rb
+++ b/spec/puppetfile_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe PuppetfileEditor::Puppetfile do
       pf.load
       expect(pf.generate_puppetfile).to eq(<<~RUBY,
         # Local modules
-        mod 'config', :local
+        mod 'config', local: true
 
         # Modules from the Puppet Forge
         mod 'puppetlabs/stdlib', '4.19.0'
@@ -86,15 +86,15 @@ RSpec.describe PuppetfileEditor::Puppetfile do
       pf.load
       expect(pf.generate_puppetfile).to eq(<<~RUBY,
         # Local modules
-        mod 'celery', :local
-        mod 'check_geoip', :local
-        mod 'config', :local
-        mod 'kibastic', :local
-        mod 'lsyncd', :local
-        mod 'mongo', :local
-        mod 's3cmd', :local
-        mod 'vcsrepo', :local
-        mod 'vpn', :local
+        mod 'celery', local: true
+        mod 'check_geoip', local: true
+        mod 'config', local: true
+        mod 'kibastic', local: true
+        mod 'lsyncd', local: true
+        mod 'mongo', local: true
+        mod 's3cmd', local: true
+        mod 'vcsrepo', local: true
+        mod 'vpn', local: true
 
         # Modules from the Puppet Forge
         mod 'puppetlabs/apache', '1.10.0'


### PR DESCRIPTION
This PR modifies the default behavior so that local modules will be written in non-legacy format.

Expect changes such as this:

```diff
 # Local modules
-mod 'my_local_module', :local
+mod 'my_local_module', local: true
```